### PR TITLE
Excluding H755 raid controller from converting to non-RAID

### DIFF
--- a/dracclient/resources/raid.py
+++ b/dracclient/resources/raid.py
@@ -932,6 +932,7 @@ class RAIDManagement(object):
         physical_disks = self.list_physical_disks()
 
         raid = constants.RaidStatus.raid
+        jbod = constants.RaidStatus.jbod
 
         if not controllers_to_physical_disk_ids:
             controllers_to_physical_disk_ids = collections.defaultdict(list)
@@ -945,6 +946,12 @@ class RAIDManagement(object):
                         physical_d.controller]
 
                     physical_disk_ids.append(physical_d.id)
+
+        # Excluding H755 RAID controller from converting to non-RAID
+        for cntlr in all_controllers:
+            if cntlr.model.startswith("PERC H755") and mode == jbod:
+                if cntlr.id in controllers_to_physical_disk_ids:
+                    del controllers_to_physical_disk_ids[cntlr.id]
 
         '''Modify controllers_to_physical_disk_ids dict by inspecting desired
         status vs current status of each controller's disks.

--- a/dracclient/resources/raid.py
+++ b/dracclient/resources/raid.py
@@ -911,13 +911,13 @@ class RAIDManagement(object):
         RAID to JBOD or vice versa.  It does this by only converting the
         disks that are not already in the correct state.
 
-        When converting H755 RAID controller physical disks to non-RAID mode,
-        RAID-0 virtual disks get created for each physical disk and disks moved
-        to 'Online' state.
+        When converting Dell EMC PERC H755 RAID controller physical disks
+        to non-RAID mode, RAID-0 virtual disks get created for each physical
+        disk and disks moved to 'Online' state.
 
         This is different from other controllers supporting non-RAID conversion
-        and takes up physical disks that cannot be used for user intended RAID
-        configuration later. H755 RAID controllers are excluded from converting
+        and takes up physical disks that cannot be later used for user intended
+        RAID configuration. H755 RAID controllers are excluded when converting
         to non-RAID mode leaving disks in 'Ready' state.
 
         :param mode: constants.RaidStatus enumeration that indicates the mode
@@ -956,9 +956,12 @@ class RAIDManagement(object):
 
                     physical_disk_ids.append(physical_d.id)
 
-        # Filter out PERC H755 controller as it creates RAID0 virtual disks
-        # when in non-RAID mode
         controllers_to_results = {}
+
+        # Filter out PERC H755 controller as it creates RAID-0 virtual disks
+        # when in non-RAID mode. Returns conversion result dictionary
+        # containing is_commit_required and is_reboot_required key with
+        # the value always set to False.
         if mode == jbod:
             for cntlr in all_controllers:
                 if cntlr.model.startswith("PERC H755") and \

--- a/dracclient/tests/wsman_mocks/controller_view-enum-ok.xml
+++ b/dracclient/tests/wsman_mocks/controller_view-enum-ok.xml
@@ -93,6 +93,55 @@
           <n1:SupportRAID10UnevenSpans>0</n1:SupportRAID10UnevenSpans>
           <n1:T10PICapability>0</n1:T10PICapability>
         </n1:DCIM_ControllerView>
+        <n1:DCIM_ControllerView>
+          <n1:AlarmState>1</n1:AlarmState>
+          <n1:BootVirtualDiskFQDD xsi:nil="true"/>
+          <n1:Bus>1</n1:Bus>
+          <n1:CacheSizeInMB>8192</n1:CacheSizeInMB>
+          <n1:CachecadeCapability>0</n1:CachecadeCapability>
+          <n1:ConfigLockdownCapable>0</n1:ConfigLockdownCapable>
+          <n1:ConfigLockdownState>0</n1:ConfigLockdownState>
+          <n1:ConnectorCount>4</n1:ConnectorCount>
+          <n1:ControllerFirmwareVersion>52.13.2-3661</n1:ControllerFirmwareVersion>
+          <n1:Device>0</n1:Device>
+          <n1:DeviceCardDataBusWidth>Unknown</n1:DeviceCardDataBusWidth>
+          <n1:DeviceCardManufacturer>DELL</n1:DeviceCardManufacturer>
+          <n1:DeviceCardSlotLength>2</n1:DeviceCardSlotLength>
+          <n1:DeviceCardSlotType>Unknown</n1:DeviceCardSlotType>
+          <n1:DeviceDescription>RAID Controller in SL 8</n1:DeviceDescription>
+          <n1:DriverVersion xsi:nil="true"/>
+          <n1:EncryptionCapability>1</n1:EncryptionCapability>
+          <n1:EncryptionMode>0</n1:EncryptionMode>
+          <n1:FQDD>RAID.SL.8-1</n1:FQDD>
+          <n1:Function>0</n1:Function>
+          <n1:InstanceID>RAID.SL.8-1</n1:InstanceID>
+          <n1:KeyID xsi:nil="true"/>
+          <n1:LastSystemInventoryTime>20210831081620.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20210831081620.000000+000</n1:LastUpdateTime>
+          <n1:MaxAvailablePCILinkSpeed xsi:nil="true"/>
+          <n1:MaxPossiblePCILinkSpeed xsi:nil="true"/>
+          <n1:PCIDeviceID>10E2</n1:PCIDeviceID>
+          <n1:PCISlot xsi:nil="true"/>
+          <n1:PCISubDeviceID>1AE1</n1:PCISubDeviceID>
+          <n1:PCISubVendorID>1028</n1:PCISubVendorID>
+          <n1:PCIVendorID>1000</n1:PCIVendorID>
+          <n1:PatrolReadState>1</n1:PatrolReadState>
+          <n1:PersistentHotspare>0</n1:PersistentHotspare>
+          <n1:PrimaryStatus>0</n1:PrimaryStatus>
+          <n1:ProductName>PERC H755 Front</n1:ProductName>
+          <n1:RealtimeCapability>0</n1:RealtimeCapability>
+          <n1:RollupStatus>0</n1:RollupStatus>
+          <n1:SASAddress>52CEA7F06A603500</n1:SASAddress>
+          <n1:SecurityStatus>1</n1:SecurityStatus>
+          <n1:SharedSlotAssignmentAllowed>0</n1:SharedSlotAssignmentAllowed>
+          <n1:SlicedVDCapability>1</n1:SlicedVDCapability>
+          <n1:SupportControllerBootMode>0</n1:SupportControllerBootMode>
+          <n1:SupportEnhancedAutoForeignImport>1</n1:SupportEnhancedAutoForeignImport>
+          <n1:SupportRAID10UnevenSpans>1</n1:SupportRAID10UnevenSpans>
+          <n1:T10PICapability>0</n1:T10PICapability>
+          <n1:UpdateLockdownCapable>0</n1:UpdateLockdownCapable>
+          <n1:UpdateLockdownState>0</n1:UpdateLockdownState>
+        </n1:DCIM_ControllerView>
       </wsman:Items>
       <wsen:EnumerationContext/>
       <wsman:EndOfSequence/>

--- a/dracclient/tests/wsman_mocks/physical_disk_view-enum-ok.xml
+++ b/dracclient/tests/wsman_mocks/physical_disk_view-enum-ok.xml
@@ -199,6 +199,43 @@
           <n1:T10PICapability>0</n1:T10PICapability>
           <n1:UsedSizeInBytes>0</n1:UsedSizeInBytes>
         </n1:DCIM_PhysicalDiskView>
+	<n1:DCIM_PhysicalDiskView>
+          <n1:BlockSizeInBytes>512</n1:BlockSizeInBytes>
+          <n1:BusProtocol>6</n1:BusProtocol>
+          <n1:Connector>0</n1:Connector>
+          <n1:DeviceDescription>Disk 0 in Backplane 1 of Int RAID Controller 1</n1:DeviceDescription>
+          <n1:DriveFormFactor>2</n1:DriveFormFactor>
+          <n1:FQDD>Disk.Bay.0:Enclosure.Internal.0-1:RAID.SL.8-1</n1:FQDD>
+          <n1:FreeSizeInBytes>599550590976</n1:FreeSizeInBytes>
+          <n1:HotSpareStatus>0</n1:HotSpareStatus>
+          <n1:InstanceID>Disk.Bay.0:Enclosure.Internal.0-1:RAID.SL.8-1</n1:InstanceID>
+          <n1:LastSystemInventoryTime>20150226180025.000000+000</n1:LastSystemInventoryTime>
+          <n1:LastUpdateTime>20150226180025.000000+000</n1:LastUpdateTime>
+          <n1:Manufacturer>SEAGATE </n1:Manufacturer>
+          <n1:ManufacturingDay>2</n1:ManufacturingDay>
+          <n1:ManufacturingWeek>33</n1:ManufacturingWeek>
+          <n1:ManufacturingYear>2014</n1:ManufacturingYear>
+          <n1:MaxCapableSpeed>3</n1:MaxCapableSpeed>
+          <n1:MediaType>0</n1:MediaType>
+          <n1:Model>ST600MM0006     </n1:Model>
+          <n1:OperationName>None</n1:OperationName>
+          <n1:OperationPercentComplete>0</n1:OperationPercentComplete>
+          <n1:PPID>CN07YX587262248G01MHA02 </n1:PPID>
+          <n1:PredictiveFailureState>0</n1:PredictiveFailureState>
+          <n1:PrimaryStatus>1</n1:PrimaryStatus>
+          <n1:RaidStatus>1</n1:RaidStatus>
+          <n1:RemainingRatedWriteEndurance>255</n1:RemainingRatedWriteEndurance>
+          <n1:Revision>LS0A</n1:Revision>
+          <n1:RollupStatus>1</n1:RollupStatus>
+          <n1:SASAddress>5000C5007764FF6D</n1:SASAddress>
+          <n1:SecurityState>0</n1:SecurityState>
+          <n1:SerialNumber>S0M3EVL6            </n1:SerialNumber>
+          <n1:SizeInBytes>599550590976</n1:SizeInBytes>
+          <n1:Slot>0</n1:Slot>
+          <n1:SupportedEncryptionTypes>None</n1:SupportedEncryptionTypes>
+          <n1:T10PICapability>0</n1:T10PICapability>
+          <n1:UsedSizeInBytes>0</n1:UsedSizeInBytes>
+        </n1:DCIM_PhysicalDiskView>
         <n2:DCIM_PCIeSSDView>
           <n2:BusProtocol>7</n2:BusProtocol>
           <n2:Bus>3E</n2:Bus>


### PR DESCRIPTION
Hi Guys,
Please have a look into changes for excluding h755 controller from conversion when mode is non-RAID